### PR TITLE
[%s] 출력 오류 _ Update page-header.php

### DIFF
--- a/layouts/mobile/_includes/page-header.php
+++ b/layouts/mobile/_includes/page-header.php
@@ -1,6 +1,6 @@
 <div class="page-header rb-page-header">
 	<h1><?php echo $_FHM['name']?></h1>
 	<p>
-		<?php echo $_FHM['addinfo']?$_FHM['addinfo']:_LANG('s1001','xlayout')?>
+		<?php echo $_FHM['addinfo']?$_FHM['addinfo']:sprintf(_LANG('s1001','xlayout'),$_FHM['name'])?>
 	</p>
 </div>


### PR DESCRIPTION
메뉴 네임을 불러오지 못한 채 [%s]로 표기됩니다. layouts/default 소스 참고하였습니다. 정상 출력될지 모르겠네요. 관리자용 코멘트가 너무 어렵습니다. 대신 '메뉴 부가설명을 넣어주세요' 라고 표기하고 관리자페이지 관련 링크넣어 바로 갈 수 있게 해 주면 더 좋을 거 같습니다. layouts/default 의 s1001을 위와 같이 적용하면 더 편리할 듯 합니다.