### PR TITLE
jquery-timeago 스위치 추가

### DIFF
--- a/_var/switch.var.php
+++ b/_var/switch.var.php
@@ -1,6 +1,7 @@
 <?php
 $d['switch']['start']['filterip'] = "";
 $d['switch']['head']['lazy-load-xt'] = "";
+$d['switch']['head']['jquery-timeago-ko'] = "";
 $d['switch']['foot']['lightbox'] = "";
 $d['switch']['end']['visitorcheck'] = "";
 ?>

--- a/switches/head/jquery-timeago-ko/main.php
+++ b/switches/head/jquery-timeago-ko/main.php
@@ -1,0 +1,26 @@
+<!-- jquery-timeago  --> 
+<?php getImport('jquery-timeago','jquery.timeago',false,'js')?> 
+
+<script>
+// Korean
+jQuery.timeago.settings.strings = {
+	suffixAgo: "전",
+	suffixFromNow: "후",
+	seconds: "1분 이내",
+	minute: "1분",
+	minutes: "%d분",
+	hour: "1시간",
+	hours: "%d시간",
+	day: "하루",
+	days: "%d일",
+	month: "한 달",
+	months: "%d달",
+	year: "1년",
+	years: "%d년",
+	wordSeparator: " "
+};
+
+jQuery(document).ready(function() {
+	$(".timeago").timeago();
+});
+</script>

--- a/switches/head/jquery-timeago-ko/name.txt
+++ b/switches/head/jquery-timeago-ko/name.txt
@@ -1,0 +1,1 @@
+﻿jquery-timeago-ko

--- a/switches/head/jquery-timeago-ko/readme.txt
+++ b/switches/head/jquery-timeago-ko/readme.txt
@@ -1,0 +1,12 @@
+﻿<h1>jquery-timeago-ko 스위치 이용안내</h1>
+<h3>[의존성]</h3>
+아래 플러그인이 있어야 함 (기본패키지에 내장 됨)
+<code>/plugins/jquery-timeago</code>
+<h3>[적용형식]</h3>
+<code>&lt;time class="timeago" datetime="년-월-일 시:분"&gt;&lt;/time&gt;</code>
+<h3>[게시물 예시]</h3>
+<code>&lt;time class="timeago" datetime="&lt;?php echo getDateFormat($_R['d_regis'],'Y-m-d H:i')?&gt;"&gt;&lt;/time&gt;</code>
+
+참고자료 
+<a href="https://github.com/rmm5t/jquery-timeago" target="_blank">https://github.com/rmm5t/jquery-timeago</a>
+<a href="http://ko.wikipedia.org/wiki/ISO_8601" target="_blank">http://ko.wikipedia.org/wiki/ISO_8601</a>


### PR DESCRIPTION
- 필요성 :  사이트 전체 영역에서 경과시간 형식 시간표현을 위해서 jquery-timeago 플러그인 적용이 필요하며 , 플러그인의 간편하고 효율적인 적용을 위해 스위치 방식이 유리함
- 페이지 및 게시물등록시간, 회원관련 시간표현에서 다양하게 활용되기 때문에 기본 스위치로 처리가 필요함 
  
  jquery-timeago 플러그인을 게시물 추출위젯에 반영한 예제 
  ![image](https://cloud.githubusercontent.com/assets/5070245/7648541/0f49e390-fb1f-11e4-9493-83f5e4ae3d6f.png)
