### PR TITLE
Editor 무한로딩 현상 해결방안

### DIFF
--- a/modules/editor/theme/default/main.php
+++ b/modules/editor/theme/default/main.php
@@ -94,6 +94,7 @@ function setEditMode()
 	EditForm = frames.editAreaIframe;
 	EditForm.document.designMode = 'on';
 	EditForm.document.write(getId('setCssCode').innerHTML.replace(/&lt;/g,'<').replace(/&gt;/g,'>'));
+	EditForm.document.close();
 
 	EditRange = EditForm.document.selection;
 	if(navigator.userAgent.indexOf('Chrome') != -1 || navigator.userAgent.indexOf('Safari') != -1) frames.editAreaIframe.focus();


### PR DESCRIPTION
크롬 브라우져에서 게시판 및 댓글 글쓰기시 무한로딩 현상이 발생하여 이를 수정하기 위함
------------
안녕하세요. 케르입니다.

제 나름대로의 조사를 통해 얻은 결론은 아래와 같습니다. 

## 문제의 원인으로 지목된 코드 분석 및 용도
    
 1. 문제의 원인으로 언급된 아래의 코드가 본 이슈의 원인인 것은 맞습니다.  
    `EditForm.document.write(getId('setCssCode').innerHTML.replace(/&lt;/g,'<').replace(/&gt;/g,'>'));`  
 2. 단지, 위 코드에서 원인으로 지목된  `&lt;` 를 `<` 로 변환하는 과정은 문제가 없는 것으로 보입니다.
 3. 이 코드의 용도는 댓글 박스 내부의 style 을 지정하기 위한 것으로 실제 해당 `iframe` 내부 
     `<head></head>` 안에 `style` 이 지정되어 있습니다.  따라서, 이 코드가 필요없다고 할 수는 없다고 생각합니다. 
 4. 테스트 해보시면 아시겠지만, 이 코드를 삭제했을 경우 댓글 박스에 글을 쓰면 폰트나 라인
      간격 등이 투박하게 출력이 됩니다. 

## 그렇다면 무엇이 문제인가? 

위에서 말씀드린 대로 문제의 원인은 아래 코드가 제공합니다. 
`EditForm.document.write(getId('setCssCode').innerHTML.replace(/&lt;/g,'<').replace(/&gt;/g,'>'));`

 그러나 진짜 원인은... `getId('setCssCode').innerHTML.replace(/&lt;/g,'<').replace(/&gt;/g,'>')`
가 아니라.....`document.write()` 메소드 사용방법상의 오류로 보여집니다. 

즉, `document.write()` 메소드를 사용한 이후에는 반드시 `document.close()` 메소드를 해줘야한다는 것입니다. 

실제로...위 코드 아래에...아래의 한 줄 추가해주면 무한로딩 현상은 사라집니다.
`EditForm.document.close();`


##  왜 크롬에서만 그런가? 

이 부분에 대한 힌트는 아래 글을 참조해주시기 바랍니다. 
* [Chrome Javascript and frames not working](http://www.stackoverflow.com/questions/22842749/chrome-javascript-and-frames-not-working)


##  왜 최근에 이 문제가 이슈가 되었는가? 

   이 부분에 대해서는 아래의 2 가지 경우로 추측합니다. 

   1. 킴스큐 커뮤니티가 발견을 이제서 한 것이다.
   2. 크롬의 업그레이드가 진행되면서 iframe 에 대한 룰이 엄격해졌다.(보안 이슈)


기타 추가로 참고할만한 링크는 아래와 같습니다. 
* [Javascript document.open and document.close is necessary?](http://stackoverflow.com/questions/27854494/javascript-document-open-and-document-close-is-necessary)
* [Why does document.write() always cause the browsers tab to show the loading… indicator?](http://stackoverflow.com/questions/7114798/why-does-document-write-always-cause-the-browsers-tab-to-show-the-loading-i)

이상입니다. .