### PR TITLE
액션파일 중복 인클루드되어 액션이 2 번 처리되는 오류 수정

### DIFF
--- a/_core/engine/action.engine.php
+++ b/_core/engine/action.engine.php
@@ -17,7 +17,7 @@ if (strpos(',join,',$a))
 }
 
 $g['act_module0'] = $g['dir_module'].$a.'.php';
-$g['act_module1'] = $g['dir_module'].'action/'.(strpos($a,'/')?str_replace('/','/a.',$a):'a.'.$a).'.php';
+if(strpos($a,'/')) $g['act_module1'] = $g['dir_module'].'action/'.str_replace('/','/a.',$a).'.php';	
 $g['act_module2'] = $g['dir_module'].'action/a.'.$a.'.php';
 $g['act_module3'] = $g['referer'] && strpos($g['referer'],'&m=admin&') ? ($_HMD['lang']?$_HMD['lang']:$d['admin']['syslang']) : ($_HS['lang']?$_HS['lang']:$d['admin']['syslang']);
 


### PR DESCRIPTION
최종적으로 아래와 같이 파일을 인클루드 하게 되는데....
if (is_file($g['act_module1'])) include $g['act_module1'];
if (is_file($g['act_module2'])) include $g['act_module2'];

수정 전 코드의 경우 $a 값에 '/' 가 없는 경우 $g['act_module2'] 파일과 같은 파일을 지정하게 되어서 결국
$g['act_module2'] 파일을 2 번 인클루드 하게 되는 현상이 발생한다.